### PR TITLE
manifest: Don't track Terminal package from LineageOS

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -557,7 +557,6 @@
   <project path="packages/apps/Stk" remote="lineage" name="android_packages_apps_Stk" groups="apps_stk,pdk-fs" />
   <project path="packages/apps/StorageManager" remote="lineage" name="android_packages_apps_StorageManager" groups="pdk-fs" />
   <project path="packages/apps/Tag" remote="lineage" name="android_packages_apps_Tag" groups="pdk-fs" />
-  <project path="packages/apps/Terminal" remote="lineage" name="android_packages_apps_Terminal" groups="pdk-fs" />
   <project path="packages/apps/Test/connectivity" name="platform/packages/apps/Test/connectivity" groups="pdk" remote="aosp" />
   <project path="packages/apps/ThemePicker" remote="lineage" name="android_packages_apps_ThemePicker" groups="pdk-fs" />
   <project path="packages/apps/Traceur" remote="lineage" name="android_packages_apps_Traceur" groups="pdk-fs" />


### PR DESCRIPTION
* https://github.com/exthmui/android/commit/e6c801d03c01d6846f0132805cddcf2285ae1107 is removed Terminal and libvterm.
  But why add it https://github.com/exthmui/android/blob/exthm-11/default.xml#L560

* This fix:
  error: packages/apps/Terminal.jni/Android bp:1:1: "libjni_terminal" depends on undefined module "libvterm"

Signed-off-by: anrui2032 <anrui2032@gmail.com>